### PR TITLE
pve_disk_passthrough.sh에서 select_disk 함수 버그 수정

### DIFF
--- a/pve_disk_passthrough.sh
+++ b/pve_disk_passthrough.sh
@@ -118,7 +118,7 @@ select_disk() {
                 fi
             fi
         fi
-    done < <(lsblk -dnb -o NAME,SIZE,MODEL | awk 'NR>1{
+    done < <(lsblk -dnb -o NAME,SIZE,MODEL | awk '{
         dev=$1; 
         size=$2;
         model=substr($0, index($0,$3));


### PR DESCRIPTION
`lsblk -dnb -o NAME,SIZE,MODEL | awk 'NR>1{ ...`
lsblk -n 옵션은 "No headings(헤더 없음)"을 의미한다고 합니다. 즉, 첫 번째 줄부터 바로 디스크 데이터가 나옵니다.

그런데 뒤따르는 awk 'NR>1'은 "첫 번째 줄을 건너뛰라"는 뜻입니다.

결과: 시스템에서 첫 번째로 인식된 디스크(보통 /dev/sda)가 패스스루를 원하는 디스크라면, 이 코드 때문에 무조건 목록에서 제외돼버리는 버그가 발생했습니다.